### PR TITLE
Build full netconf stack for arm64 as well as for amd64

### DIFF
--- a/.github/workflows/build_debs.yml
+++ b/.github/workflows/build_debs.yml
@@ -57,6 +57,8 @@ jobs:
           git clone https://github.com/CESNET/Netopeer2.git 
           sed -i 's/-DCMAKE_BUILD_TYPE/-DENABLE_TLS=ON -DENABLE_SSH=ON -DCMAKE_BUILD_TYPE/g' \
              ~/libnetconf2/distro/pkg/deb/rules
+          # workaround until https://github.com/sysrepo/sysrepo/issues/3670 reaches master
+          sed -i 's/x86_64-linux-gnu/*/g' ~/lisysrepo/distro/pkg/deb/libsysrepo7.install
 
       - name: build libyang
         run: |

--- a/.github/workflows/build_debs.yml
+++ b/.github/workflows/build_debs.yml
@@ -58,7 +58,7 @@ jobs:
           sed -i 's/-DCMAKE_BUILD_TYPE/-DENABLE_TLS=ON -DENABLE_SSH=ON -DCMAKE_BUILD_TYPE/g' \
              ~/libnetconf2/distro/pkg/deb/rules
           # workaround until https://github.com/sysrepo/sysrepo/issues/3670 reaches master
-          sed -i 's/x86_64-linux-gnu/*/g' ~/lisysrepo/distro/pkg/deb/libsysrepo7.install
+          sed -i 's/x86_64-linux-gnu/*/g' ~/sysrepo/distro/pkg/deb/libsysrepo7.install
 
       - name: build libyang
         run: |

--- a/.github/workflows/build_debs.yml
+++ b/.github/workflows/build_debs.yml
@@ -59,6 +59,8 @@ jobs:
              ~/libnetconf2/distro/pkg/deb/rules
           # workaround until https://github.com/sysrepo/sysrepo/issues/3670 reaches master
           sed -i 's/x86_64-linux-gnu/*/g' ~/sysrepo/distro/pkg/deb/libsysrepo7.install
+          cd ~/sysrepo/
+          git commit -a -m "Patch for https://github.com/sysrepo/sysrepo/issues/3670"
 
       - name: build libyang
         run: |

--- a/.github/workflows/build_debs.yml
+++ b/.github/workflows/build_debs.yml
@@ -60,8 +60,7 @@ jobs:
           # workaround until https://github.com/sysrepo/sysrepo/issues/3670 reaches master
           sed -i 's/x86_64-linux-gnu/*/g' ~/sysrepo/distro/pkg/deb/libsysrepo7.install
           cd ~/sysrepo/
-          git commit -a -m "Patch for https://github.com/sysrepo/sysrepo/issues/3670"
-
+          git commit -a -m "Patch for https://github.com/sysrepo/sysrepo/issues/3670" --author="bot <nobody@ipronics.com>"
       - name: build libyang
         run: |
           cd ~/libyang && uv tool run apkg build

--- a/.github/workflows/build_debs.yml
+++ b/.github/workflows/build_debs.yml
@@ -60,7 +60,9 @@ jobs:
           # workaround until https://github.com/sysrepo/sysrepo/issues/3670 reaches master
           sed -i 's/x86_64-linux-gnu/*/g' ~/sysrepo/distro/pkg/deb/libsysrepo7.install
           cd ~/sysrepo/
-          git commit -a -m "Patch for https://github.com/sysrepo/sysrepo/issues/3670" --author="bot <nobody@ipronics.com>"
+          git config user.email "bot@ipronics.com"
+          git config user.name "Bot"
+          git commit -a -m "Patch for https://github.com/sysrepo/sysrepo/issues/3670"
       - name: build libyang
         run: |
           cd ~/libyang && uv tool run apkg build

--- a/.github/workflows/build_debs.yml
+++ b/.github/workflows/build_debs.yml
@@ -8,8 +8,16 @@ on:
       - "*"
 
 jobs:
-  build-amd64:
-    runs-on: ubuntu-latest
+  build:
+    strategy:
+      matrix:
+        include:
+          - os: "ubuntu-latest"
+            arch: "amd64"
+          - os: "ubuntu-24.04-arm"
+            arch: "arm64"
+
+    runs-on: ${{ matrix.os }}
     container:
       image: ghcr.io/astral-sh/uv:bookworm-slim
     outputs:
@@ -81,60 +89,13 @@ jobs:
       - name: Upload builds as artifacts
         uses: actions/upload-artifact@v4
         with:
-          name: builds-amd64
-          path: ~/builds/
-          retention-days: 7
-
-  build-arm64:
-    runs-on: ubuntu-24.04-arm
-    container:
-      image: ghcr.io/astral-sh/uv:bookworm-slim
-    outputs:
-      artifact_id: ${{ steps.upload-artifact.outputs.artifact-id }}
-      keyring: ${{ steps.create-apt-repo.outputs.keyring }}
-    steps:
-      - name: Install apkg
-        run: uv tool install apkg
-      - name: Install build deps
-        run: |
-          apt-get update && apt-get install -y --no-install-recommends \
-            git \
-            build-essential \
-            libcmocka-dev \
-            libpcre2-dev \
-            pkg-config \
-            cmake \
-            debhelper
-
-      - name: download sources
-        run: |
-          git config --global http.sslVerify false 
-          cd ~
-          git clone https://github.com/CESNET/libyang
-
-      - name: build libyang
-        run: |
-          cd ~/libyang && uv tool run apkg build 
-          apt-get install -y ~/libyang/pkg/pkgs/debian-12/libyang*/*.deb
-
-      - name: build libyang wheel
-        run: |
-          mkdir -p ~/wheels && cd ~/wheels && uvx -p 3.11 pip wheel libyang
-
-      - name: Collect all builds
-        run: |
-          mkdir -p ~/builds && cp ~/*/pkg/pkgs/debian-12/*/* ~/wheels/*.whl ~/builds/
-
-      - name: Upload builds as artifacts
-        uses: actions/upload-artifact@v4
-        with:
-          name: builds-arm64
+          name: builds-${{ matrix.arch }}
           path: ~/builds/
           retention-days: 7
 
   release:
     if: github.ref_type == 'tag'
-    needs: [build-amd64, build-arm64]
+    needs: build
     runs-on: ubuntu-latest
     steps:
       - name: Checkout

--- a/.github/workflows/build_debs.yml
+++ b/.github/workflows/build_debs.yml
@@ -52,12 +52,18 @@ jobs:
           git config --global http.sslVerify false 
           cd ~
           git clone https://github.com/CESNET/libyang  
-          git clone https://github.com/CESNET/libnetconf2.git 
-          # Workaround until the bugfix of #sysrepo/3670 lands on sysrepo's master
-          git clone https://github.com/cpascual/sysrepo.git  --branch bugfix-3670
+          git clone https://github.com/CESNET/libnetconf2.git  
+          git clone https://github.com/sysrepo/sysrepo.git  
           git clone https://github.com/CESNET/Netopeer2.git 
           sed -i 's/-DCMAKE_BUILD_TYPE/-DENABLE_TLS=ON -DENABLE_SSH=ON -DCMAKE_BUILD_TYPE/g' \
              ~/libnetconf2/distro/pkg/deb/rules
+          # workaround until https://github.com/sysrepo/sysrepo/issues/3670 reaches master
+          sed -i 's/x86_64-linux-gnu/*/g' ~/sysrepo/distro/pkg/deb/libsysrepo7.install
+          sed -i 's/x86_64-linux-gnu/*/g' ~/sysrepo/distro/pkg/deb/sysrepo-tools.install
+          cd ~/sysrepo/
+          git config user.email "bot@ipronics.com"
+          git config user.name "Bot"
+          git commit -a -m "Patch for https://github.com/sysrepo/sysrepo/issues/3670"
 
       - name: build libyang
         run: |

--- a/.github/workflows/build_debs.yml
+++ b/.github/workflows/build_debs.yml
@@ -52,17 +52,13 @@ jobs:
           git config --global http.sslVerify false 
           cd ~
           git clone https://github.com/CESNET/libyang  
-          git clone https://github.com/CESNET/libnetconf2.git  
-          git clone https://github.com/sysrepo/sysrepo.git  
+          git clone https://github.com/CESNET/libnetconf2.git 
+          # Workaround until the bugfix of #sysrepo/3670 lands on sysrepo's master
+          git clone https://github.com/cpascual/sysrepo.git  --branch bugfix-3670
           git clone https://github.com/CESNET/Netopeer2.git 
           sed -i 's/-DCMAKE_BUILD_TYPE/-DENABLE_TLS=ON -DENABLE_SSH=ON -DCMAKE_BUILD_TYPE/g' \
              ~/libnetconf2/distro/pkg/deb/rules
-          # workaround until https://github.com/sysrepo/sysrepo/issues/3670 reaches master
-          sed -i 's/x86_64-linux-gnu/*/g' ~/sysrepo/distro/pkg/deb/libsysrepo7.install
-          cd ~/sysrepo/
-          git config user.email "bot@ipronics.com"
-          git config user.name "Bot"
-          git commit -a -m "Patch for https://github.com/sysrepo/sysrepo/issues/3670"
+
       - name: build libyang
         run: |
           cd ~/libyang && uv tool run apkg build


### PR DESCRIPTION
This PR:
- simplifies the build_deb workflow (uses a matrix strategy instead of duplicating code)
- builds  the whole stack for arm
- Adds a workaround for [a bug I detected in the upstream code of sysrepo](https://github.com/sysrepo/sysrepo/issues/3670)